### PR TITLE
Add `eos.macros.fire()` to Eos Console

### DIFF
--- a/src/modules/macros.ts
+++ b/src/modules/macros.ts
@@ -22,4 +22,8 @@ export class MacrosModule extends RecordTargetModule<'macro'> {
     async get(targetNumber: TargetNumber): Promise<Macro | null> {
         return this.getEos().request(MacroRequest.get(targetNumber));
     }
+
+    async fire(targetNumber: TargetNumber): Promise<Macro | null> {
+        return this.getEos().request(MacroRequest.fire(targetNumber));
+    }
 }

--- a/src/modules/macros.ts
+++ b/src/modules/macros.ts
@@ -24,6 +24,6 @@ export class MacrosModule extends RecordTargetModule<'macro'> {
     }
 
     async fire(targetNumber: TargetNumber): Promise<void> {
-        await this.getEos().sendMessage(`/eos/macros/${targetNumber}/fire`);
+        await this.getEos().sendMessage(`/eos/macro/${targetNumber}/fire`);
     }
 }

--- a/src/modules/macros.ts
+++ b/src/modules/macros.ts
@@ -23,7 +23,7 @@ export class MacrosModule extends RecordTargetModule<'macro'> {
         return this.getEos().request(MacroRequest.get(targetNumber));
     }
 
-    async fire(targetNumber: TargetNumber): Promise<Macro | null> {
-        return this.getEos().request(MacroRequest.fire(targetNumber));
+    async fire(targetNumber: TargetNumber): Promise<void> {
+        await this.getEos().sendMessage(`/eos/macros/${targetNumber}/fire`);
     }
 }

--- a/src/requests/macro-request.ts
+++ b/src/requests/macro-request.ts
@@ -15,10 +15,6 @@ export class MacroRequest extends RecordTargetRequest<Macro> {
         return new MacroRequest(`/eos/get/macro/${targetNumber}`, 2);
     }
 
-    static fire(targetNumber: TargetNumber) {
-        return new MacroRequest(`/eos/macro/${targetNumber}/fire`);
-    }
-
     protected override unpack(messages: OscMessage[]): Macro {
         return {
             targetType: 'macro',

--- a/src/requests/macro-request.ts
+++ b/src/requests/macro-request.ts
@@ -15,6 +15,10 @@ export class MacroRequest extends RecordTargetRequest<Macro> {
         return new MacroRequest(`/eos/get/macro/${targetNumber}`, 2);
     }
 
+    static fire(targetNumber: TargetNumber) {
+        return new MacroRequest(`/eos/macro/${targetNumber}/fire`);
+    }
+
     protected override unpack(messages: OscMessage[]): Macro {
         return {
             targetType: 'macro',


### PR DESCRIPTION
I added the ability to fire macros from an EosConsole. It takes in the TargetNumber and returns the target macro.